### PR TITLE
feat(pool options): add ability to use custom error encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # CHANGELOG
 
+# v2.8.0-rc.4 (09.02.2022)
+
+## 👀 New:
+
+- ✏️ Pool: add a new option to override the custom error encoder: `pool.WithCustomErrEncoder`. 
+
+---
+
+# v2.8.0-rc.3 (04.02.2022)
+
+## 📦 Packages:
+
+- 📦 tcplisten `v1.1.1`
+
+---
+
+# v2.8.0-rc.2 (29.01.2022)
+
+## 📦 Packages:
+
+- 📦 goridge `v3.3.1`
+
+---
+
 # v2.8.0-rc.1 (21.01.2022)
 
 ## 👀 New:

--- a/pool/options.go
+++ b/pool/options.go
@@ -1,0 +1,17 @@
+package pool
+
+import (
+	"go.uber.org/zap"
+)
+
+func WithLogger(z *zap.Logger) Options {
+	return func(p *StaticPool) {
+		p.log = z
+	}
+}
+
+func WithCustomErrEncoder(errEnc ErrorEncoder) Options {
+	return func(p *StaticPool) {
+		p.errEncoder = errEnc
+	}
+}

--- a/pool/static_pool.go
+++ b/pool/static_pool.go
@@ -67,6 +67,8 @@ func NewStaticPool(ctx context.Context, cmd Command, factory ipc.Factory, cfg *C
 		factory: factory,
 	}
 
+	p.errEncoder = defaultErrEncoder(p)
+
 	// add pool options
 	for i := 0; i < len(options); i++ {
 		options[i](p)
@@ -98,8 +100,6 @@ func NewStaticPool(ctx context.Context, cmd Command, factory ipc.Factory, cfg *C
 		return nil, err
 	}
 
-	p.errEncoder = defaultErrEncoder(p)
-
 	// if supervised config not nil, guess, that pool wanted to be supervised
 	if cfg.Supervisor != nil {
 		sp := supervisorWrapper(p, p.log, p.cfg.Supervisor)
@@ -109,12 +109,6 @@ func NewStaticPool(ctx context.Context, cmd Command, factory ipc.Factory, cfg *C
 	}
 
 	return p, nil
-}
-
-func WithLogger(z *zap.Logger) Options {
-	return func(p *StaticPool) {
-		p.log = z
-	}
 }
 
 // GetConfig returns associated pool configuration. Immutable.

--- a/pool/static_pool_test.go
+++ b/pool/static_pool_test.go
@@ -192,7 +192,7 @@ func Test_StaticPool_Echo_CustomErrEncoder(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, res)
-	assert.Equal(t, "foo", err.Error())
+	assert.Contains(t, err.Error(), "foo")
 }
 
 func Test_StaticPool_JobError(t *testing.T) {


### PR DESCRIPTION
# Reason for This PR

- Custom error handler for the static pool.

## Description of Changes

- Add pool option to override the default error encoder
- Add tests

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
