### PR TITLE
bug(ww): destroy operation hangs if the number of workers is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+# v2.8.0-rc.5 (10.02.2022)
+
+## 🩹 Fixes:
+
+- 🐛 Fix: destroy operation hangs if the number of workers is 0: [BUG](https://github.com/roadrunner-server/roadrunner/issues/1003), (reporter @benalf)
+
+---
+
 # v2.8.0-rc.4 (09.02.2022)
 
 ## 👀 New:


### PR DESCRIPTION
# Reason for This PR

- closes: https://github.com/roadrunner-server/roadrunner/issues/1003

## Description of Changes

- Immediately return when there are no workers, thus, nothing to destroy.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
