### PR TITLE
bug(worker): fix worker panic on bad response

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,6 +13,6 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v2 # Action page: <https://github.com/golangci/golangci-lint-action>
         with:
-          version: v1.43 # without patch version
+          version: v1.44 # without patch version
           only-new-issues: false # show only new issues if it's a pull request
           args: --timeout=10m --build-tags=race

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,8 +26,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ["7.4", "8.0", "8.1"]
-        go: ["1.17.6"]
+        php: ["8.0", "8.1"]
+        go: ["1.17.7"]
         os: ["ubuntu-latest"]
     steps:
       - name: Set up Go ${{ matrix.go }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+# v2.8.0 (11.02.2022)
+
+## 🩹 Fixes:
+
+- 🐛 Fix: worker sometimes panics when unix/tcp sockets transport used: [BUG](https://github.com/roadrunner-server/roadrunner/issues/1006), (reporter @tarampampam)
+
 # v2.8.0-rc.5 (10.02.2022)
 
 ## 🩹 Fixes:

--- a/pool/options.go
+++ b/pool/options.go
@@ -15,3 +15,9 @@ func WithCustomErrEncoder(errEnc ErrorEncoder) Options {
 		p.errEncoder = errEnc
 	}
 }
+
+func UseParallelAlloc() Options {
+	return func(p *StaticPool) {
+		p.parallelAlloc = true
+	}
+}

--- a/worker/sync_worker.go
+++ b/worker/sync_worker.go
@@ -207,6 +207,11 @@ func (tw *SyncWorkerImpl) execPayload(p *payload.Payload) (*payload.Payload, err
 		return nil, errors.E(op, errors.Decode, errors.Str("options length should be equal 1 (body offset)"))
 	}
 
+	// bound check
+	if len(frameR.Payload()) < int(options[0]) {
+		return nil, errors.E(errors.Network, errors.Errorf("bad payload %s", frameR.Payload()))
+	}
+
 	pld := &payload.Payload{
 		Codec:   flags,
 		Body:    make([]byte, len(frameR.Payload()[options[0]:])),


### PR DESCRIPTION
# Reason for This PR

- closes: #https://github.com/roadrunner-server/roadrunner/issues/1006

## Description of Changes

- Do not allocate workers in parallel if the workers uses `unix/tcp sockets`

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
