### PR TITLE
fix: racing container assigment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,12 +27,3 @@ updates:
       - "rustatian"
     assignees:
       - "rustatian"
-
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: daily
-    reviewers:
-      - "rustatian"
-    assignees:
-      - "rustatian"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         php: ["8.0", "8.1"]
         go: ["1.18"]
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest"]
     steps:
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v3 # action page: <https://github.com/actions/setup-go>

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         php: ["8.0", "8.1"]
         go: ["1.18"]
-        os: ["ubuntu-latest"]
+        os: ["ubuntu-latest", "macos-latest"]
     steps:
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v3 # action page: <https://github.com/actions/setup-go>


### PR DESCRIPTION
# Reason for This PR

- races during the temporal heavy recovery test

## Description of Changes

- Reset the container internally, w/o making a new one as the replacement.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
