### PR TITLE
fix: incorrect `Reset` mutex order

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Primary owners
+
+@wolfy-j @rustatian

--- a/worker_watcher/container/channel/vec.go
+++ b/worker_watcher/container/channel/vec.go
@@ -115,12 +115,13 @@ func (v *Vec) Pop(ctx context.Context) (worker.BaseProcess, error) {
 
 	// used only for the TTL-ed workers
 	v.rwm.RLock()
-	defer v.rwm.RUnlock()
 
 	select {
 	case w := <-v.workers:
+		v.rwm.RUnlock()
 		return w, nil
 	case <-ctx.Done():
+		v.rwm.RUnlock()
 		return nil, errors.E(ctx.Err(), errors.NoFreeWorkers)
 	}
 }

--- a/worker_watcher/worker_watcher.go
+++ b/worker_watcher/worker_watcher.go
@@ -15,8 +15,8 @@ import (
 	"go.uber.org/zap"
 )
 
-// Vector interface represents vector container
-type Vector interface {
+// Vector interface represents vector container (internal)
+type vector interface {
 	// Push used to put worker to the vector
 	Push(worker.BaseProcess)
 	// Pop used to get worker from the vector
@@ -27,6 +27,10 @@ type Vector interface {
 	Destroy()
 	// Reset used to reset the internal ww state
 	Reset()
+	// ResetDone used to finish the reset operation
+	ResetDone()
+	// Drain used to remove all workers from the underlying container
+	Drain()
 
 	// TODO(rustatian) Add Replace method, and remove `Remove` method. Replace will do removal and allocation
 	// Replace(prevPid int64, newWorker worker.BaseProcess)
@@ -34,7 +38,7 @@ type Vector interface {
 
 type workerWatcher struct {
 	sync.RWMutex
-	container Vector
+	container vector
 	// used to control Destroy stage (that all workers are in the container)
 	numWorkers *uint64
 	stopped    *uint64
@@ -85,10 +89,8 @@ func (ww *workerWatcher) Watch(workers []worker.BaseProcess) error {
 func (ww *workerWatcher) Take(ctx context.Context) (worker.BaseProcess, error) {
 	const op = errors.Op("worker_watcher_get_free_worker")
 	// we need lock here to prevent Pop operation when ww in the resetting state
-	ww.RLock()
 	// thread safe operation
 	w, err := ww.container.Pop(ctx)
-	ww.RUnlock()
 
 	if err != nil {
 		if errors.Is(errors.WatcherStopped, err) {
@@ -230,7 +232,7 @@ func (ww *workerWatcher) Reset(ctx context.Context) {
 	// destroy container, we don't use ww mutex here, since we should be able to push worker
 	ww.Lock()
 	// do not release new workers
-	ww.container.Destroy()
+	ww.container.Reset()
 	ww.Unlock()
 
 	tt := time.NewTicker(time.Millisecond * 10)
@@ -250,7 +252,7 @@ func (ww *workerWatcher) Reset(ctx context.Context) {
 			ww.Lock()
 
 			// drain channel
-			_, _ = ww.container.Pop(ctx)
+			ww.container.Drain()
 			for i := 0; i < len(ww.workers); i++ {
 				ww.workers[i].State().Set(worker.StateDestroyed)
 				// kill the worker
@@ -258,12 +260,12 @@ func (ww *workerWatcher) Reset(ctx context.Context) {
 			}
 
 			ww.workers = make([]worker.BaseProcess, 0, atomic.LoadUint64(ww.numWorkers))
-			ww.container.Reset()
+			ww.container.ResetDone()
 			ww.Unlock()
 			return
 		case <-ctx.Done():
 			// drain channel
-			_, _ = ww.container.Pop(ctx)
+			ww.container.Drain()
 			// kill workers
 			ww.Lock()
 			for i := 0; i < len(ww.workers); i++ {
@@ -273,7 +275,7 @@ func (ww *workerWatcher) Reset(ctx context.Context) {
 			}
 
 			ww.workers = make([]worker.BaseProcess, 0, atomic.LoadUint64(ww.numWorkers))
-			ww.container.Reset()
+			ww.container.ResetDone()
 			ww.Unlock()
 		}
 	}


### PR DESCRIPTION
# Reason for This PR

ref: https://github.com/temporalio/roadrunner-temporal/issues/223

## Description of Changes

- Use mutex for the `Pop` operation

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
