### PR TITLE
feat: get rid of the `context timeout exceeded` error message

### DIFF
--- a/ipc/pipe/pipe_factory.go
+++ b/ipc/pipe/pipe_factory.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 
 	"github.com/roadrunner-server/api/v2/worker"
+	"github.com/roadrunner-server/errors"
 	"github.com/roadrunner-server/goridge/v3/pkg/pipe"
 	"github.com/roadrunner-server/sdk/v2/internal"
 	workerImpl "github.com/roadrunner-server/sdk/v2/worker"
@@ -130,7 +131,7 @@ func (f *Factory) SpawnWorkerWithTimeout(ctx context.Context, cmd *exec.Cmd) (wo
 
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, errors.E(errors.TimeOut)
 	case res := <-spCh:
 		if res.err != nil {
 			return nil, res.err

--- a/ipc/socket/socket_factory.go
+++ b/ipc/socket/socket_factory.go
@@ -155,7 +155,7 @@ func (f *Factory) SpawnWorkerWithTimeout(ctx context.Context, cmd *exec.Cmd) (wo
 
 	select {
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, errors.E(errors.TimeOut)
 	case res := <-c:
 		if res.err != nil {
 			return nil, res.err
@@ -207,7 +207,7 @@ func (f *Factory) findRelayWithContext(ctx context.Context, w worker.BaseProcess
 	for {
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return nil, errors.E(errors.TimeOut)
 		case <-ticker.C:
 			// check for the process exists
 			_, err := process.NewProcess(int32(w.Pid()))

--- a/ipc/socket/socket_factory_test.go
+++ b/ipc/socket/socket_factory_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/roadrunner-server/api/v2/payload"
+	"github.com/roadrunner-server/errors"
 	workerImpl "github.com/roadrunner-server/sdk/v2/worker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -151,7 +152,7 @@ func Test_Tcp_Timeout(t *testing.T) {
 	w, err := NewSocketServer(ls, time.Millisecond*1, log).SpawnWorkerWithTimeout(ctx, cmd)
 	assert.Nil(t, w)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "context deadline exceeded")
+	assert.True(t, errors.Is(errors.TimeOut, err))
 }
 
 func Test_Tcp_Invalid(t *testing.T) {
@@ -369,7 +370,7 @@ func Test_Unix_Timeout(t *testing.T) {
 	w, err := NewSocketServer(ls, time.Millisecond*100, log).SpawnWorkerWithTimeout(ctx, cmd)
 	assert.Nil(t, w)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "context deadline exceeded")
+	assert.True(t, errors.Is(errors.TimeOut, err))
 }
 
 func Test_Unix_Invalid(t *testing.T) {

--- a/pool/allocator.go
+++ b/pool/allocator.go
@@ -19,6 +19,10 @@ func (sp *Pool) newPoolAllocator(ctx context.Context, timeout time.Duration, fac
 		defer cancel()
 		w, err := factory.SpawnWorkerWithTimeout(ctxT, cmd(sp.cfg.Command))
 		if err != nil {
+			// context deadline
+			if errors.Is(errors.TimeOut, err) {
+				return nil, errors.Str("failed to spawn a worker, possible reasons: https://roadrunner.dev/docs/known-issues-allocate-timeout/2.x/en")
+			}
 			return nil, err
 		}
 


### PR DESCRIPTION
# Reason for This PR

- clear error description.

## Description of Changes

- new error message: `failed to spawn a worker, possible reasons: https://roadrunner.dev/docs/known-issues-allocate-timeout/2.x/en`
- Instead of a low-level, Go-related error message, users will see the new message starting from the next release with a link to the `roadrunner.dev` docs explaining the possible reasons for such errors.
- https://roadrunner.dev/docs/known-issues-allocate-timeout/2.x/en

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
