### PR TITLE
bug: use context timeout to spawn workers via sockets/tcp server relays

### DIFF
--- a/ipc/socket/socket_factory.go
+++ b/ipc/socket/socket_factory.go
@@ -24,14 +24,11 @@ import (
 type Factory struct {
 	// listens for incoming connections from underlying processes
 	ls net.Listener
-
 	// relay connection timeout
 	tout time.Duration
-
 	// sockets which are waiting for process association
 	relays sync.Map
-
-	log *zap.Logger
+	log    *zap.Logger
 }
 
 // NewSocketServer returns Factory attached to a given socket listener.
@@ -94,8 +91,6 @@ type socketSpawn struct {
 func (f *Factory) SpawnWorkerWithTimeout(ctx context.Context, cmd *exec.Cmd) (worker.BaseProcess, error) {
 	c := make(chan socketSpawn)
 	go func() {
-		ctxT, cancel := context.WithTimeout(ctx, f.tout)
-		defer cancel()
 		w, err := workerImpl.InitBaseWorker(cmd, workerImpl.WithLog(f.log))
 		if err != nil {
 			select {
@@ -122,7 +117,7 @@ func (f *Factory) SpawnWorkerWithTimeout(ctx context.Context, cmd *exec.Cmd) (wo
 			}
 		}
 
-		rl, err := f.findRelayWithContext(ctxT, w)
+		rl, err := f.findRelayWithContext(ctx, w)
 		if err != nil {
 			_ = w.Kill()
 			select {

--- a/ipc/socket/socket_factory_test.go
+++ b/ipc/socket/socket_factory_test.go
@@ -111,7 +111,8 @@ func Test_Tcp_StartError(t *testing.T) {
 
 func Test_Tcp_Failboot(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	defer cancel()
 
 	ls, err := net.Listen("tcp", "127.0.0.1:9007")
 	if assert.NoError(t, err) {
@@ -134,7 +135,9 @@ func Test_Tcp_Failboot(t *testing.T) {
 
 func Test_Tcp_Timeout(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Microsecond)
+	defer cancel()
+
 	ls, err := net.Listen("tcp", "127.0.0.1:9007")
 	if assert.NoError(t, err) {
 		defer func() {
@@ -157,7 +160,8 @@ func Test_Tcp_Timeout(t *testing.T) {
 
 func Test_Tcp_Invalid(t *testing.T) {
 	time.Sleep(time.Millisecond * 10) // to ensure free socket
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 	ls, err := net.Listen("tcp", "127.0.0.1:9007")
 	if assert.NoError(t, err) {
 		defer func() {
@@ -332,7 +336,6 @@ func Test_Unix_Start(t *testing.T) {
 
 func Test_Unix_Failboot(t *testing.T) {
 	ls, err := net.Listen("unix", "sock.unix")
-	ctx := context.Background()
 	if err == nil {
 		defer func() {
 			err = ls.Close()
@@ -344,6 +347,9 @@ func Test_Unix_Failboot(t *testing.T) {
 		t.Skip("socket is busy")
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
 	cmd := exec.Command("php", "../../tests/failboot.php")
 
 	w, err := NewSocketServer(ls, time.Second*5, log).SpawnWorkerWithTimeout(ctx, cmd)
@@ -353,7 +359,6 @@ func Test_Unix_Failboot(t *testing.T) {
 
 func Test_Unix_Timeout(t *testing.T) {
 	ls, err := net.Listen("unix", "sock.unix")
-	ctx := context.Background()
 	if err == nil {
 		defer func() {
 			err = ls.Close()
@@ -366,6 +371,8 @@ func Test_Unix_Timeout(t *testing.T) {
 	}
 
 	cmd := exec.Command("php", "../../tests/slow-client.php", "echo", "unix", "200", "0")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*100)
+	defer cancel()
 
 	w, err := NewSocketServer(ls, time.Millisecond*100, log).SpawnWorkerWithTimeout(ctx, cmd)
 	assert.Nil(t, w)
@@ -374,7 +381,6 @@ func Test_Unix_Timeout(t *testing.T) {
 }
 
 func Test_Unix_Invalid(t *testing.T) {
-	ctx := context.Background()
 	ls, err := net.Listen("unix", "sock.unix")
 	if err == nil {
 		defer func() {
@@ -388,6 +394,8 @@ func Test_Unix_Invalid(t *testing.T) {
 	}
 
 	cmd := exec.Command("php", "../../tests/invalid.php")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
 
 	w, err := NewSocketServer(ls, time.Second*10, log).SpawnWorkerWithTimeout(ctx, cmd)
 	assert.Error(t, err)


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1226

## Description of Changes

- For the server plugin, we have a `relay_timeout`. It is used for the `socket/tcp` relays to wait for the connection from the PHP worker. After the fix, the allocator will use a `pool.allocate_timeout` option instead of overwriting this timeout with a `server.relay_timeout`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
