### PR TITLE
feature: `reset_timeout` option

### DIFF
--- a/ipc/pipe/pipe_factory_test.go
+++ b/ipc/pipe/pipe_factory_test.go
@@ -169,36 +169,6 @@ func Test_Pipe_Echo(t *testing.T) {
 	assert.Equal(t, "hello", res.String())
 }
 
-func Test_Pipe_Echo_Script(t *testing.T) {
-	t.Skip("not supported")
-	cmd := exec.Command("sh", "../../tests/pipes_test_script.sh")
-	ctx := context.Background()
-	w, err := NewPipeFactory(log).SpawnWorkerWithTimeout(ctx, cmd)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		err = w.Stop()
-		if err != nil {
-			t.Errorf("error stopping the Process: error %v", err)
-		}
-	}()
-
-	res, err := w.Exec(&payload.Payload{Body: []byte("hello")})
-	assert.NoError(t, err)
-	assert.NotNil(t, res)
-	assert.NotNil(t, res.Body)
-	assert.Empty(t, res.Context)
-
-	go func() {
-		if w.Wait() != nil {
-			t.Fail()
-		}
-	}()
-
-	assert.Equal(t, "hello", res.String())
-}
-
 func Test_Pipe_Broken(t *testing.T) {
 	t.Parallel()
 	cmd := exec.Command("php", "../../tests/client.php", "broken", "pipes")

--- a/ipc/socket/socket_factory_test.go
+++ b/ipc/socket/socket_factory_test.go
@@ -259,45 +259,6 @@ func Test_Tcp_Echo(t *testing.T) {
 	assert.Equal(t, "hello", res.String())
 }
 
-func Test_Tcp_Echo_Script(t *testing.T) {
-	t.Skip("not supported")
-	time.Sleep(time.Millisecond * 10) // to ensure free socket
-	ctx := context.Background()
-	ls, err := net.Listen("tcp", "127.0.0.1:9007")
-	if assert.NoError(t, err) {
-		defer func() {
-			err = ls.Close()
-			if err != nil {
-				t.Errorf("error closing the listener: error %v", err)
-			}
-		}()
-	} else {
-		t.Skip("socket is busy")
-	}
-
-	cmd := exec.Command("sh", "../../tests/socket_test_script.sh")
-
-	w, _ := NewSocketServer(ls, time.Minute, log).SpawnWorkerWithTimeout(ctx, cmd)
-	go func() {
-		assert.NoError(t, w.Wait())
-	}()
-	defer func() {
-		err = w.Stop()
-		if err != nil {
-			t.Errorf("error stopping the Process: error %v", err)
-		}
-	}()
-
-	res, err := w.Exec(&payload.Payload{Body: []byte("hello")})
-
-	assert.NoError(t, err)
-	assert.NotNil(t, res)
-	assert.NotNil(t, res.Body)
-	assert.Empty(t, res.Context)
-
-	assert.Equal(t, "hello", res.String())
-}
-
 func Test_Unix_Start(t *testing.T) {
 	ctx := context.Background()
 	ls, err := net.Listen("unix", "sock.unix")

--- a/pool/config.go
+++ b/pool/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	NumWorkers uint64 `mapstructure:"num_workers"`
 
 	// MaxJobs defines how many executions is allowed for the worker until
-	// it's destruction. set 1 to create new process for each new task, 0 to let
+	// its destruction. set 1 to create new process for each new task, 0 to let
 	// worker handle as many tasks as it can.
 	MaxJobs uint64 `mapstructure:"max_jobs"`
 
@@ -29,6 +29,9 @@ type Config struct {
 	// DestroyTimeout defines for how long pool should be waiting for worker to
 	// properly destroy, if timeout reached worker will be killed. Defaults to 60s.
 	DestroyTimeout time.Duration `mapstructure:"destroy_timeout"`
+
+	// ResetTimeout defines how long pool should wait before start killing workers
+	ResetTimeout time.Duration `mapstructure:"reset_timeout"`
 
 	// Supervision config to limit worker and pool memory usage.
 	Supervisor *SupervisorConfig `mapstructure:"supervisor"`
@@ -47,6 +50,11 @@ func (cfg *Config) InitDefaults() {
 	if cfg.DestroyTimeout == 0 {
 		cfg.DestroyTimeout = time.Minute
 	}
+
+	if cfg.ResetTimeout == 0 {
+		cfg.ResetTimeout = time.Minute
+	}
+
 	if cfg.Supervisor == nil {
 		return
 	}
@@ -57,7 +65,7 @@ type SupervisorConfig struct {
 	// WatchTick defines how often to check the state of worker.
 	WatchTick time.Duration `mapstructure:"watch_tick"`
 
-	// TTL defines maximum time worker is allowed to live.
+	// TTL defines maximum time for the worker is allowed to live.
 	TTL time.Duration `mapstructure:"ttl"`
 
 	// IdleTTL defines maximum duration worker can spend in idle mode. Disabled when 0.


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1352

## Description of Changes

- Add a new option to the pool: `reset_timeout`. This option controls the maximum timeout for the pool reset operation (re-allocate all workers).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
