### PR TITLE
feature(priority queue): `Remove` method with monotonic stack

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,8 +26,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.1"]
-        go: ["1.19"]
+        php: ["8.2"]
+        go: ["1.20"]
         os: ["ubuntu-latest"]
     steps:
       - name: Set up Go ${{ matrix.go }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Spiral Scout
+Copyright (c) 2023 Spiral Scout
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/priority_queue/binary_heap.go
+++ b/priority_queue/binary_heap.go
@@ -109,7 +109,7 @@ func (bh *BinHeap[T]) Remove(id string) []T {
 		end := ids[i][1] - adjusment
 
 		bh.items = append(bh.items[:start], bh.items[end+1:]...)
-		adjusment = adjusment + (end - start + 1)
+		adjusment += end - start + 1
 	}
 
 	atomic.StoreUint64(&bh.len, uint64(len(bh.items)))

--- a/priority_queue/binary_heap_test.go
+++ b/priority_queue/binary_heap_test.go
@@ -8,17 +8,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type Test struct {
 	priority int64
+	id       string
 }
 
-func NewTest(priority int64) Test {
+func NewTest(priority int64, id string) Test {
 	return Test{
 		priority: priority,
+		id:       id,
 	}
 }
 
@@ -31,7 +34,7 @@ func (t Test) Context() ([]byte, error) {
 }
 
 func (t Test) ID() string {
-	return "none"
+	return t.id
 }
 
 func (t Test) Priority() int64 {
@@ -40,17 +43,17 @@ func (t Test) Priority() int64 {
 
 func TestBinHeap_Init(t *testing.T) {
 	a := []Item{
-		NewTest(2),
-		NewTest(23),
-		NewTest(33),
-		NewTest(44),
-		NewTest(1),
-		NewTest(2),
-		NewTest(2),
-		NewTest(2),
-		NewTest(4),
-		NewTest(6),
-		NewTest(99),
+		NewTest(2, uuid.NewString()),
+		NewTest(23, uuid.NewString()),
+		NewTest(33, uuid.NewString()),
+		NewTest(44, uuid.NewString()),
+		NewTest(1, uuid.NewString()),
+		NewTest(2, uuid.NewString()),
+		NewTest(2, uuid.NewString()),
+		NewTest(2, uuid.NewString()),
+		NewTest(4, uuid.NewString()),
+		NewTest(6, uuid.NewString()),
+		NewTest(99, uuid.NewString()),
 	}
 
 	bh := NewBinHeap[Item](12)
@@ -59,25 +62,26 @@ func TestBinHeap_Init(t *testing.T) {
 		bh.Insert(a[i])
 	}
 
-	expected := []Item{
-		NewTest(1),
-		NewTest(2),
-		NewTest(2),
-		NewTest(2),
-		NewTest(2),
-		NewTest(4),
-		NewTest(6),
-		NewTest(23),
-		NewTest(33),
-		NewTest(44),
-		NewTest(99),
+	expected := []int64{
+		1,
+		2,
+		2,
+		2,
+		2,
+		4,
+		6,
+		23,
+		33,
+		44,
+		99,
 	}
 
-	res := make([]Item, 0, 12)
+	res := make([]int64, 0, 12)
 
 	for i := 0; i < 11; i++ {
 		item := bh.ExtractMin()
-		res = append(res, item)
+		item.Priority()
+		res = append(res, item.Priority())
 	}
 
 	require.Equal(t, expected, res)
@@ -85,17 +89,17 @@ func TestBinHeap_Init(t *testing.T) {
 
 func TestBinHeap_MaxLen(t *testing.T) {
 	a := []Item{
-		NewTest(2),
-		NewTest(23),
-		NewTest(33),
-		NewTest(44),
-		NewTest(1),
-		NewTest(2),
-		NewTest(2),
-		NewTest(2),
-		NewTest(4),
-		NewTest(6),
-		NewTest(99),
+		NewTest(2, uuid.NewString()),
+		NewTest(23, uuid.NewString()),
+		NewTest(33, uuid.NewString()),
+		NewTest(44, uuid.NewString()),
+		NewTest(1, uuid.NewString()),
+		NewTest(2, uuid.NewString()),
+		NewTest(2, uuid.NewString()),
+		NewTest(2, uuid.NewString()),
+		NewTest(4, uuid.NewString()),
+		NewTest(6, uuid.NewString()),
+		NewTest(99, uuid.NewString()),
 	}
 
 	bh := NewBinHeap[Item](1)
@@ -171,7 +175,7 @@ func TestNewPriorityQueue(t *testing.T) {
 			case <-stopCh:
 				return
 			default:
-				pq.Insert(NewTest(rand.Int63())) //nolint:gosec
+				pq.Insert(NewTest(rand.Int63(), uuid.NewString())) //nolint:gosec
 				atomic.AddUint64(&insertsPerSec, 1)
 			}
 		}
@@ -186,17 +190,17 @@ func TestNewPriorityQueue(t *testing.T) {
 
 func TestNewItemWithTimeout(t *testing.T) {
 	a := []Item{
-		NewTest(5),
-		NewTest(23),
-		NewTest(33),
-		NewTest(44),
-		NewTest(5),
-		NewTest(5),
-		NewTest(6),
-		NewTest(7),
-		NewTest(8),
-		NewTest(6),
-		NewTest(99),
+		NewTest(5, uuid.NewString()),
+		NewTest(23, uuid.NewString()),
+		NewTest(33, uuid.NewString()),
+		NewTest(44, uuid.NewString()),
+		NewTest(5, uuid.NewString()),
+		NewTest(5, uuid.NewString()),
+		NewTest(6, uuid.NewString()),
+		NewTest(7, uuid.NewString()),
+		NewTest(8, uuid.NewString()),
+		NewTest(6, uuid.NewString()),
+		NewTest(99, uuid.NewString()),
 	}
 
 	/*
@@ -217,17 +221,17 @@ func TestNewItemWithTimeout(t *testing.T) {
 
 func TestItemPeek(t *testing.T) {
 	a := []Item{
-		NewTest(5),
-		NewTest(23),
-		NewTest(33),
-		NewTest(44),
-		NewTest(5),
-		NewTest(5),
-		NewTest(6),
-		NewTest(7),
-		NewTest(8),
-		NewTest(6),
-		NewTest(99),
+		NewTest(5, uuid.NewString()),
+		NewTest(23, uuid.NewString()),
+		NewTest(33, uuid.NewString()),
+		NewTest(44, uuid.NewString()),
+		NewTest(5, uuid.NewString()),
+		NewTest(5, uuid.NewString()),
+		NewTest(6, uuid.NewString()),
+		NewTest(7, uuid.NewString()),
+		NewTest(8, uuid.NewString()),
+		NewTest(6, uuid.NewString()),
+		NewTest(99, uuid.NewString()),
 	}
 
 	/*
@@ -251,17 +255,17 @@ func TestItemPeek(t *testing.T) {
 
 func TestItemPeekConcurrent(t *testing.T) {
 	a := []Item{
-		NewTest(5),
-		NewTest(23),
-		NewTest(33),
-		NewTest(44),
-		NewTest(5),
-		NewTest(5),
-		NewTest(6),
-		NewTest(7),
-		NewTest(8),
-		NewTest(6),
-		NewTest(99),
+		NewTest(5, uuid.NewString()),
+		NewTest(23, uuid.NewString()),
+		NewTest(33, uuid.NewString()),
+		NewTest(44, uuid.NewString()),
+		NewTest(5, uuid.NewString()),
+		NewTest(5, uuid.NewString()),
+		NewTest(6, uuid.NewString()),
+		NewTest(7, uuid.NewString()),
+		NewTest(8, uuid.NewString()),
+		NewTest(6, uuid.NewString()),
+		NewTest(99, uuid.NewString()),
 	}
 
 	/*
@@ -293,4 +297,54 @@ func TestItemPeekConcurrent(t *testing.T) {
 	}()
 
 	wg.Wait()
+}
+
+func TestBinHeap_Remove(t *testing.T) {
+	a := []Item{
+		NewTest(2, "1"),
+		NewTest(5, "1"),
+		NewTest(99, "1"),
+		NewTest(4, "6"),
+		NewTest(6, "7"),
+		NewTest(23, "2"),
+		NewTest(2, "1"),
+		NewTest(2, "1"),
+		NewTest(33, "3"),
+		NewTest(44, "4"),
+		NewTest(2, "1"),
+	}
+
+	bh := NewBinHeap[Item](12)
+
+	for i := 0; i < len(a); i++ {
+		bh.Insert(a[i])
+	}
+
+	expected := []Item{
+		NewTest(4, "6"),
+		NewTest(6, "7"),
+		NewTest(23, "2"),
+		NewTest(33, "3"),
+		NewTest(44, "4"),
+	}
+
+	out := bh.Remove("1")
+	if len(out) != 6 {
+		t.Fatal("should be 5")
+	}
+
+	for i := 0; i < len(out); i++ {
+		if out[i].ID() != "1" {
+			t.Fatal("id is not 1")
+		}
+	}
+
+	res := make([]Item, 0, 12)
+
+	for i := 0; i < 5; i++ {
+		item := bh.ExtractMin()
+		res = append(res, item)
+	}
+
+	require.Equal(t, expected, res)
 }

--- a/priority_queue/monotinic_stack.go
+++ b/priority_queue/monotinic_stack.go
@@ -1,0 +1,49 @@
+package priorityqueue
+
+type stack struct {
+	/*
+		[] - slice with intervals
+		[2] - array with start and end intervals
+	*/
+	idx [][2]int
+}
+
+func newStack() *stack {
+	return &stack{
+		idx: make([][2]int, 0, 10),
+	}
+}
+
+func (st *stack) add(idx int) {
+	/*
+		we have to store the beginning of the range + the last
+	*/
+
+	// st.intervals[len(st.intervals)-1][1] - last seen interval
+
+	// firstly seen
+	if len(st.idx) == 0 {
+		st.idx = append(st.idx, [2]int{
+			idx, idx,
+		})
+		return
+	}
+
+	// last[1] is a previously added element
+	if st.idx[len(st.idx)-1][1]+1 == idx {
+		st.idx[len(st.idx)-1][1] = idx
+		return
+	}
+
+	st.idx = append(st.idx, [2]int{
+		idx, idx,
+	})
+}
+
+func (st *stack) indices() [][2]int {
+	return st.idx
+}
+
+func (st *stack) clear() {
+	st.idx = make([][2]int, 0, 10)
+}

--- a/priority_queue/monotonic_stack_test.go
+++ b/priority_queue/monotonic_stack_test.go
@@ -1,0 +1,33 @@
+package priorityqueue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMonotonicStackInit(t *testing.T) {
+	c := newStack()
+	c.add(1)
+	c.add(2)
+	c.add(3)
+	c.add(5)
+	c.add(6)
+	c.add(10)
+	c.add(14)
+
+	assert.Equal(t, [][2]int{{1, 3}, {5, 6}, {10, 10}, {14, 14}}, c.indices())
+}
+
+func TestMonotonicStackLastStartEl(t *testing.T) {
+	c := newStack()
+	c.add(1)
+	c.add(3)
+	c.add(5)
+	c.add(7)
+	c.add(9)
+	c.add(11)
+	c.add(13)
+
+	assert.Equal(t, [][2]int{{1, 1}, {3, 3}, {5, 5}, {7, 7}, {9, 9}, {11, 11}, {13, 13}}, c.indices())
+}


### PR DESCRIPTION
# Reason for This PR

ref: https://github.com/roadrunner-server/roadrunner/issues/1382

## Description of Changes

- Add Remove operation to the Priority Queue (+ Monotonic stack to track the continuous intervals).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
