### PR TITLE
fix: do not kill the worker during the check

### DIFF
--- a/fsm/state.go
+++ b/fsm/state.go
@@ -31,4 +31,7 @@ const (
 
 	// StateErrored - error StateImpl (can't be used).
 	StateErrored
+
+	// StateIdleTTLReached - worker idle TTL was reached state
+	StateIdleTTLReached
 )

--- a/pool/static_pool/fuzz_test.go
+++ b/pool/static_pool/fuzz_test.go
@@ -17,9 +17,9 @@ func FuzzStaticPoolEcho(f *testing.F) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		testCfg,
-		log,
+		log(),
 	)
 	assert.NoError(f, err)
 	assert.NotNil(f, p)

--- a/pool/static_pool/static_pool_test.go
+++ b/pool/static_pool/static_pool_test.go
@@ -28,16 +28,19 @@ var testCfg = &pool.Config{
 	DestroyTimeout:  time.Second * 500,
 }
 
-var log = zap.NewNop()
+var log = func() *zap.Logger {
+	logger, _ := zap.NewDevelopment()
+	return logger
+}
 
 func Test_NewPool(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		testCfg,
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
@@ -56,7 +59,7 @@ func Test_StaticPool_NilFactory(t *testing.T) {
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		nil,
 		testCfg,
-		log,
+		log(),
 	)
 	assert.Error(t, err)
 	assert.Nil(t, p)
@@ -67,9 +70,9 @@ func Test_StaticPool_NilConfig(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		nil,
-		log,
+		log(),
 	)
 	assert.Error(t, err)
 	assert.Nil(t, p)
@@ -81,9 +84,9 @@ func Test_StaticPool_ImmediateDestroy(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		testCfg,
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
@@ -102,9 +105,9 @@ func Test_StaticPool_RemoveWorker(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		testCfg,
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
@@ -132,16 +135,13 @@ func Test_Poll_Reallocate(t *testing.T) {
 		DestroyTimeout:  time.Second * 500,
 	}
 
-	logDev, err := zap.NewDevelopment()
-	require.NoError(t, err)
-
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		testCfg2,
-		logDev,
+		log(),
 	)
 	require.NoError(t, err)
 	require.NotNil(t, p)
@@ -184,9 +184,9 @@ func Test_NewPoolReset(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		testCfg2,
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
@@ -234,9 +234,9 @@ func Test_StaticPool_Invalid(t *testing.T) {
 	p, err := NewPool(
 		context.Background(),
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/invalid.php") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		testCfg,
-		log,
+		log(),
 	)
 
 	assert.Nil(t, p)
@@ -247,12 +247,12 @@ func Test_ConfigNoErrorInitDefaults(t *testing.T) {
 	p, err := NewPool(
 		context.Background(),
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			AllocateTimeout: time.Second,
 			DestroyTimeout:  time.Second,
 		},
-		log,
+		log(),
 	)
 
 	assert.NotNil(t, p)
@@ -265,9 +265,9 @@ func Test_StaticPool_Echo(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		testCfg,
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 
@@ -290,9 +290,9 @@ func Test_StaticPool_Echo_NilContext(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		testCfg,
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 
@@ -315,9 +315,9 @@ func Test_StaticPool_Echo_Context(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "head", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		testCfg,
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 
@@ -340,9 +340,9 @@ func Test_StaticPool_JobError(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "error", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		testCfg,
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
@@ -370,7 +370,7 @@ func Test_StaticPool_Broken_Replace(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "broken", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		testCfg,
 		z,
 	)
@@ -397,7 +397,7 @@ func Test_StaticPool_Broken_FromOutside(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		cfg2,
 		nil,
 	)
@@ -436,13 +436,13 @@ func Test_StaticPool_AllocateTimeout(t *testing.T) {
 	p, err := NewPool(
 		context.Background(),
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "delay", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      1,
 			AllocateTimeout: time.Nanosecond * 1,
 			DestroyTimeout:  time.Second * 2,
 		},
-		log,
+		log(),
 	)
 	assert.Error(t, err)
 	if !errors.Is(errors.WorkerAllocate, err) {
@@ -456,14 +456,14 @@ func Test_StaticPool_Replace_Worker(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "pid", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      1,
 			MaxJobs:         1,
 			AllocateTimeout: time.Second * 5,
 			DestroyTimeout:  time.Second,
 		},
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
@@ -497,13 +497,13 @@ func Test_StaticPool_Debug_Worker(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "pid", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			Debug:           true,
 			AllocateTimeout: time.Second,
 			DestroyTimeout:  time.Second,
 		},
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
@@ -540,13 +540,13 @@ func Test_StaticPool_Stop_Worker(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "stop", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      1,
 			AllocateTimeout: time.Second,
 			DestroyTimeout:  time.Second,
 		},
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
@@ -582,13 +582,13 @@ func Test_Static_Pool_Destroy_And_Close(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "delay", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      1,
 			AllocateTimeout: time.Second,
 			DestroyTimeout:  time.Second,
 		},
-		log,
+		log(),
 	)
 
 	assert.NotNil(t, p)
@@ -605,13 +605,13 @@ func Test_Static_Pool_Destroy_And_Close_While_Wait(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "delay", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      1,
 			AllocateTimeout: time.Second,
 			DestroyTimeout:  time.Second,
 		},
-		log,
+		log(),
 	)
 
 	assert.NotNil(t, p)
@@ -638,13 +638,13 @@ func Test_Static_Pool_Handle_Dead(t *testing.T) {
 		func(cmd string) *exec.Cmd {
 			return exec.Command("php", "../../tests/slow-destroy.php", "echo", "pipes")
 		},
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      5,
 			AllocateTimeout: time.Second * 100,
 			DestroyTimeout:  time.Second,
 		},
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
@@ -666,13 +666,13 @@ func Test_Static_Pool_Slow_Destroy(t *testing.T) {
 		func(cmd string) *exec.Cmd {
 			return exec.Command("php", "../../tests/slow-destroy.php", "echo", "pipes")
 		},
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      5,
 			AllocateTimeout: time.Second,
 			DestroyTimeout:  time.Second,
 		},
-		log,
+		log(),
 	)
 
 	assert.NoError(t, err)
@@ -688,7 +688,7 @@ func Test_StaticPool_ResetTimeout(t *testing.T) {
 		ctx,
 		// sleep for the 3 seconds
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/sleep.php", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			Debug:           false,
 			NumWorkers:      2,
@@ -696,7 +696,7 @@ func Test_StaticPool_ResetTimeout(t *testing.T) {
 			DestroyTimeout:  time.Second * 100,
 			ResetTimeout:    time.Second * 3,
 		},
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
@@ -722,7 +722,7 @@ func Test_StaticPool_NoFreeWorkers(t *testing.T) {
 		ctx,
 		// sleep for the 3 seconds
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/sleep.php", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			Debug:           false,
 			NumWorkers:      1,
@@ -730,7 +730,7 @@ func Test_StaticPool_NoFreeWorkers(t *testing.T) {
 			DestroyTimeout:  time.Second,
 			Supervisor:      nil,
 		},
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
@@ -756,7 +756,7 @@ func Test_StaticPool_QueueSize(t *testing.T) {
 		ctx,
 		// sleep for the 3 seconds
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/sleep_short.php", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			Debug:           false,
 			NumWorkers:      1,
@@ -764,7 +764,7 @@ func Test_StaticPool_QueueSize(t *testing.T) {
 			DestroyTimeout:  time.Second,
 			Supervisor:      nil,
 		},
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
@@ -790,13 +790,13 @@ func Test_Static_Pool_WrongCommand1(t *testing.T) {
 		func(cmd string) *exec.Cmd {
 			return exec.Command("phg", "../../tests/slow-destroy.php", "echo", "pipes")
 		},
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      5,
 			AllocateTimeout: time.Second,
 			DestroyTimeout:  time.Second,
 		},
-		log,
+		log(),
 	)
 
 	assert.Error(t, err)
@@ -808,13 +808,13 @@ func Test_Static_Pool_WrongCommand2(t *testing.T) {
 	p, err := NewPool(
 		context.Background(),
 		func(cmd string) *exec.Cmd { return exec.Command("php", "", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      5,
 			AllocateTimeout: time.Second,
 			DestroyTimeout:  time.Second,
 		},
-		log,
+		log(),
 	)
 
 	assert.Error(t, err)
@@ -826,9 +826,9 @@ func Test_CRC_WithPayload(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/crc_error.php") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		testCfg,
-		log,
+		log(),
 	)
 	assert.Error(t, err)
 	data := err.Error()
@@ -861,9 +861,9 @@ func Benchmark_Pool_Echo(b *testing.B) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		testCfg,
-		log,
+		log(),
 	)
 	if err != nil {
 		b.Fatal(err)
@@ -894,13 +894,13 @@ func Benchmark_Pool_Echo_Batched(b *testing.B) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      uint64(runtime.NumCPU()),
 			AllocateTimeout: time.Second * 100,
 			DestroyTimeout:  time.Second,
 		},
-		log,
+		log(),
 	)
 	assert.NoError(b, err)
 	defer p.Destroy(ctx)
@@ -937,14 +937,14 @@ func Benchmark_Pool_Echo_Replaced(b *testing.B) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      1,
 			MaxJobs:         1,
 			AllocateTimeout: time.Second,
 			DestroyTimeout:  time.Second,
 		},
-		log,
+		log(),
 	)
 	assert.NoError(b, err)
 	defer p.Destroy(ctx)

--- a/pool/static_pool/supervisor_test.go
+++ b/pool/static_pool/supervisor_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/roadrunner-server/sdk/v4/pool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 )
 
 var cfgSupervised = &pool.Config{
@@ -31,13 +30,12 @@ var cfgSupervised = &pool.Config{
 
 func Test_SupervisedPool_Exec(t *testing.T) {
 	ctx := context.Background()
-	logger, _ := zap.NewDevelopment()
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/memleak.php", "pipes") },
-		pipe.NewPipeFactory(logger),
+		pipe.NewPipeFactory(log()),
 		cfgSupervised,
-		logger,
+		log(),
 	)
 
 	require.NoError(t, err)
@@ -69,7 +67,7 @@ func Test_SupervisedPool_ImmediateDestroy(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			AllocateTimeout: time.Second * 10,
 			DestroyTimeout:  time.Second * 10,
@@ -81,7 +79,7 @@ func Test_SupervisedPool_ImmediateDestroy(t *testing.T) {
 				MaxWorkerMemory: 100,
 			},
 		},
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
@@ -99,9 +97,9 @@ func Test_SupervisedPool_NilFactory(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		nil,
-		log,
+		log(),
 	)
 	assert.Error(t, err)
 	assert.Nil(t, p)
@@ -114,7 +112,7 @@ func Test_SupervisedPool_NilConfig(t *testing.T) {
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		nil,
 		cfgSupervised,
-		log,
+		log(),
 	)
 	assert.Error(t, err)
 	assert.Nil(t, p)
@@ -126,9 +124,9 @@ func Test_SupervisedPool_RemoveWorker(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		cfgSupervised,
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
@@ -154,9 +152,9 @@ func Test_SupervisedPoolReset(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		cfgSupervised,
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
@@ -184,7 +182,7 @@ func TestSupervisedPool_ExecWithDebugMode(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/supervised.php") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			Debug:           true,
 			NumWorkers:      uint64(1),
@@ -198,7 +196,7 @@ func TestSupervisedPool_ExecWithDebugMode(t *testing.T) {
 				MaxWorkerMemory: 100,
 			},
 		},
-		log,
+		log(),
 	)
 
 	assert.NoError(t, err)
@@ -235,9 +233,9 @@ func TestSupervisedPool_ExecTTL_TimedOut(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/sleep.php", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		cfgExecTTL,
-		log,
+		log(),
 	)
 
 	assert.NoError(t, err)
@@ -271,9 +269,9 @@ func TestSupervisedPool_TTL_WorkerRestarted(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/sleep-ttl.php") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		cfgExecTTL,
-		log,
+		log(),
 	)
 
 	assert.NoError(t, err)
@@ -330,9 +328,9 @@ func TestSupervisedPool_Idle(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/idle.php", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		cfgExecTTL,
-		log,
+		log(),
 	)
 
 	assert.NoError(t, err)
@@ -380,9 +378,9 @@ func TestSupervisedPool_IdleTTL_StateAfterTimeout(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/exec_ttl.php", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		cfgExecTTL,
-		log,
+		log(),
 	)
 
 	assert.NoError(t, err)
@@ -430,9 +428,9 @@ func TestSupervisedPool_ExecTTL_OK(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/exec_ttl.php", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		cfgExecTTL,
-		log,
+		log(),
 	)
 
 	assert.NoError(t, err)
@@ -456,6 +454,47 @@ func TestSupervisedPool_ExecTTL_OK(t *testing.T) {
 	assert.Equal(t, pid, p.Workers()[0].Pid())
 }
 
+func TestSupervisedPool_ShouldRespond(t *testing.T) {
+	var cfgExecTTL = &pool.Config{
+		NumWorkers:      uint64(1),
+		AllocateTimeout: time.Minute,
+		DestroyTimeout:  time.Minute,
+		Supervisor: &pool.SupervisorConfig{
+			ExecTTL:         90 * time.Second,
+			MaxWorkerMemory: 100,
+		},
+	}
+
+	// constructed
+	// max memory
+	// constructed
+	ctx := context.Background()
+	p, err := NewPool(
+		ctx,
+		func(cmd string) *exec.Cmd {
+			return exec.Command("php", "../../tests/should-not-be-killed.php", "pipes")
+		},
+		pipe.NewPipeFactory(log()),
+		cfgExecTTL,
+		log(),
+	)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, p)
+
+	resp, err := p.Exec(ctx, &payload.Payload{
+		Context: []byte(""),
+		Body:    []byte("foo"),
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("alive"), resp.Body)
+	assert.Empty(t, resp.Context)
+
+	time.Sleep(time.Second)
+	p.Destroy(context.Background())
+}
+
 func TestSupervisedPool_MaxMemoryReached(t *testing.T) {
 	var cfgExecTTL = &pool.Config{
 		NumWorkers:      uint64(1),
@@ -477,9 +516,9 @@ func TestSupervisedPool_MaxMemoryReached(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/memleak.php", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		cfgExecTTL,
-		log,
+		log(),
 	)
 
 	assert.NoError(t, err)
@@ -503,9 +542,9 @@ func Test_SupervisedPool_FastCancel(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/sleep.php") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		cfgSupervised,
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	defer p.Destroy(ctx)
@@ -536,9 +575,9 @@ func Test_SupervisedPool_AllocateFailedOK(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/allocate-failed.php") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		cfgExecTTL,
-		log,
+		log(),
 	)
 
 	assert.NoError(t, err)
@@ -578,7 +617,7 @@ func Test_SupervisedPool_NoFreeWorkers(t *testing.T) {
 		ctx,
 		// sleep for the 3 seconds
 		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/sleep.php", "pipes") },
-		pipe.NewPipeFactory(log),
+		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			Debug:           false,
 			NumWorkers:      1,
@@ -586,7 +625,7 @@ func Test_SupervisedPool_NoFreeWorkers(t *testing.T) {
 			DestroyTimeout:  time.Second,
 			Supervisor:      &pool.SupervisorConfig{},
 		},
-		log,
+		log(),
 	)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)

--- a/tests/should-not-be-killed.php
+++ b/tests/should-not-be-killed.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+use Spiral\Goridge\StreamRelay;
+use Spiral\RoadRunner\Worker as RoadRunner;
+
+require __DIR__ . "/vendor/autoload.php";
+
+$rr = new RoadRunner(new StreamRelay(\STDIN, \STDOUT));
+$mem = '';
+while($rr->waitPayload()){
+        // Allocate some memory, this should be enough to exceed the `max_worker_memory` limit defined in
+        // .rr.yaml
+        $array = range(1, 10000000);
+        fprintf(STDERR, 'memory allocated: ' . memory_get_usage());
+        sleep(30);
+
+        $rr->respond(new \Spiral\RoadRunner\Payload("alive"));
+}

--- a/worker_watcher/worker_watcher.go
+++ b/worker_watcher/worker_watcher.go
@@ -190,7 +190,9 @@ func (ww *WorkerWatcher) Release(w *worker.Process) {
 		fsm.StateInactive,
 		fsm.StateDestroyed,
 		fsm.StateErrored,
+		fsm.StateWorking,
 		fsm.StateInvalid,
+		fsm.StateIdleTTLReached,
 		fsm.StateMaxJobsReached:
 
 		err := w.Stop()


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1561

## Description of Changes

- Do not touch the workers during the supervised checks.
- Add new state: StateIdleTTLReached for the idle ttl restarts.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
