### PR TITLE
feature: `after_init` option

### DIFF
--- a/pool/config.go
+++ b/pool/config.go
@@ -14,7 +14,7 @@ type Config struct {
 	Command string `mapstructure:"command"`
 
 	// AfterInitCommand command used to override the server's AfterInitCommand
-	AfterInitCommand string `mapstructure:"after_init_cmd"`
+	AfterInitCommand string `mapstructure:"after_init"`
 
 	// NumWorkers defines how many sub-processes can be run at once. This value
 	// might be doubled by Swapper while hot-swap. Defaults to number of CPU cores.

--- a/pool/config.go
+++ b/pool/config.go
@@ -13,6 +13,9 @@ type Config struct {
 	// Command used to override the server command with the custom one
 	Command string `mapstructure:"command"`
 
+	// AfterInitCommand command used to override the server's AfterInitCommand
+	AfterInitCommand string `mapstructure:"after_init_cmd"`
+
 	// NumWorkers defines how many sub-processes can be run at once. This value
 	// might be doubled by Swapper while hot-swap. Defaults to number of CPU cores.
 	NumWorkers uint64 `mapstructure:"num_workers"`

--- a/pool/static_pool/static_pool.go
+++ b/pool/static_pool/static_pool.go
@@ -47,7 +47,7 @@ type Pool struct {
 }
 
 // NewPool creates new worker pool and task multiplexer. Pool will initiate with one worker. If supervisor configuration is provided -> pool will be turned into a supervisedExec mode
-func NewPool(ctx context.Context, cmd pool.Command, factory pool.Factory, cfg *pool.Config, log *zap.Logger) (*Pool, error) {
+func NewPool(ctx context.Context, cmd pool.Command, factory pool.Factory, cfg *pool.Config, log *zap.Logger, options ...Options) (*Pool, error) {
 	if factory == nil {
 		return nil, errors.Str("no factory initialized")
 	}


### PR DESCRIPTION
# Reason for This PR

closes: https://github.com/roadrunner-server/roadrunner/issues/1554

## Description of Changes

- Command to be executed after pool initialization (number of executions equal to the number of plugins using the pool of workers).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
