### PR TITLE
feature: allow using `[]string` command instead of `string`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
     "errgroup",
     "Failboot",
     "goridge",
+    "mapstructure",
     "memleak",
     "nolint",
     "pexec",

--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -108,10 +108,11 @@ func (s *Fsm) recognizer(to int64) error {
 	// to
 	case StateInactive:
 		// from
+		// No-one can transition to Inactive
 		if atomic.LoadInt64(s.currentState) == StateDestroyed {
 			return errors.E(op, errors.Errorf("can't transition from state: %s", s.String()))
 		}
-	// to
+	// to from StateWorking/StateInactive only
 	case StateReady:
 		// from
 		switch atomic.LoadInt64(s.currentState) {
@@ -123,6 +124,7 @@ func (s *Fsm) recognizer(to int64) error {
 	// to
 	case StateWorking:
 		// from
+		// StateWorking can be transitioned only from StateReady
 		if atomic.LoadInt64(s.currentState) == StateReady {
 			return nil
 		}

--- a/pool/allocator.go
+++ b/pool/allocator.go
@@ -25,7 +25,7 @@ type Factory interface {
 }
 
 // NewPoolAllocator initializes allocator of the workers
-func NewPoolAllocator(ctx context.Context, timeout time.Duration, factory Factory, cmd Command, command string, log *zap.Logger) func() (*worker.Process, error) {
+func NewPoolAllocator(ctx context.Context, timeout time.Duration, factory Factory, cmd Command, command []string, log *zap.Logger) func() (*worker.Process, error) {
 	return func() (*worker.Process, error) {
 		ctxT, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()

--- a/pool/command.go
+++ b/pool/command.go
@@ -5,4 +5,4 @@ import (
 )
 
 // Command is a function that returns a new exec.Cmd instance for the given command string.
-type Command func(cmd string) *exec.Cmd
+type Command func(cmd []string) *exec.Cmd

--- a/pool/config.go
+++ b/pool/config.go
@@ -11,10 +11,10 @@ type Config struct {
 	Debug bool
 
 	// Command used to override the server command with the custom one
-	Command string `mapstructure:"command"`
+	Command []string `mapstructure:"command"`
 
 	// AfterInitCommand command used to override the server's AfterInitCommand
-	AfterInitCommand string `mapstructure:"after_init"`
+	AfterInitCommand []string `mapstructure:"after_init"`
 
 	// NumWorkers defines how many sub-processes can be run at once. This value
 	// might be doubled by Swapper while hot-swap. Defaults to number of CPU cores.

--- a/pool/static_pool/fuzz_test.go
+++ b/pool/static_pool/fuzz_test.go
@@ -16,7 +16,7 @@ func FuzzStaticPoolEcho(f *testing.F) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		testCfg,
 		log(),

--- a/pool/static_pool/supervisor_test.go
+++ b/pool/static_pool/supervisor_test.go
@@ -32,7 +32,7 @@ func Test_SupervisedPool_Exec(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/memleak.php", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/memleak.php", "pipes") },
 		pipe.NewPipeFactory(log()),
 		cfgSupervised,
 		log(),
@@ -66,7 +66,7 @@ func Test_SupervisedPool_ImmediateDestroy(t *testing.T) {
 
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			AllocateTimeout: time.Second * 10,
@@ -96,7 +96,7 @@ func Test_SupervisedPool_NilFactory(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		nil,
 		log(),
@@ -109,7 +109,7 @@ func Test_SupervisedPool_NilConfig(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		nil,
 		cfgSupervised,
 		log(),
@@ -123,7 +123,7 @@ func Test_SupervisedPool_RemoveWorker(t *testing.T) {
 
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		cfgSupervised,
 		log(),
@@ -151,7 +151,7 @@ func Test_SupervisedPoolReset(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		cfgSupervised,
 		log(),
@@ -181,7 +181,7 @@ func TestSupervisedPool_ExecWithDebugMode(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/supervised.php") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/supervised.php") },
 		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			Debug:           true,
@@ -232,7 +232,7 @@ func TestSupervisedPool_ExecTTL_TimedOut(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/sleep.php", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/sleep.php", "pipes") },
 		pipe.NewPipeFactory(log()),
 		cfgExecTTL,
 		log(),
@@ -266,7 +266,7 @@ func TestSupervisedPool_TTL_WorkerRestarted(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/sleep-ttl.php") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/sleep-ttl.php") },
 		pipe.NewPipeFactory(log()),
 		cfgExecTTL,
 		log(),
@@ -328,7 +328,7 @@ func TestSupervisedPool_Idle(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/idle.php", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/idle.php", "pipes") },
 		pipe.NewPipeFactory(log()),
 		cfgExecTTL,
 		log(),
@@ -380,7 +380,7 @@ func TestSupervisedPool_IdleTTL_StateAfterTimeout(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/exec_ttl.php", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/exec_ttl.php", "pipes") },
 		pipe.NewPipeFactory(log()),
 		cfgExecTTL,
 		log(),
@@ -432,7 +432,7 @@ func TestSupervisedPool_ExecTTL_OK(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/exec_ttl.php", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/exec_ttl.php", "pipes") },
 		pipe.NewPipeFactory(log()),
 		cfgExecTTL,
 		log(),
@@ -478,7 +478,7 @@ func TestSupervisedPool_ShouldRespond(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd {
+		func(cmd []string) *exec.Cmd {
 			return exec.Command("php", "../../tests/should-not-be-killed.php", "pipes")
 		},
 		pipe.NewPipeFactory(log()),
@@ -524,7 +524,7 @@ func TestSupervisedPool_MaxMemoryReached(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/memleak.php", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/memleak.php", "pipes") },
 		pipe.NewPipeFactory(log()),
 		cfgExecTTL,
 		log(),
@@ -552,7 +552,7 @@ func Test_SupervisedPool_FastCancel(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/sleep.php") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/sleep.php") },
 		pipe.NewPipeFactory(log()),
 		cfgSupervised,
 		log(),
@@ -583,7 +583,7 @@ func Test_SupervisedPool_AllocateFailedOK(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/allocate-failed.php") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/allocate-failed.php") },
 		pipe.NewPipeFactory(log()),
 		cfgExecTTL,
 		log(),
@@ -624,7 +624,7 @@ func Test_SupervisedPool_NoFreeWorkers(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		// sleep for the 3 seconds
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/sleep.php", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/sleep.php", "pipes") },
 		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			Debug:           false,

--- a/pool/static_pool/workers_pool_test.go
+++ b/pool/static_pool/workers_pool_test.go
@@ -37,7 +37,7 @@ func Test_NewPool(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		testCfg,
 		log(),
@@ -58,7 +58,7 @@ func Test_StaticPool_NilFactory(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		nil,
 		testCfg,
 		log(),
@@ -71,7 +71,7 @@ func Test_StaticPool_NilConfig(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		nil,
 		log(),
@@ -85,7 +85,7 @@ func Test_StaticPool_ImmediateDestroy(t *testing.T) {
 
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		testCfg,
 		log(),
@@ -106,7 +106,7 @@ func Test_StaticPool_RemoveWorker(t *testing.T) {
 
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		testCfg,
 		log(),
@@ -140,7 +140,7 @@ func Test_Poll_Reallocate(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		testCfg2,
 		log(),
@@ -185,7 +185,7 @@ func Test_NewPoolReset(t *testing.T) {
 
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		testCfg2,
 		log(),
@@ -238,7 +238,7 @@ func Test_NewPoolReset(t *testing.T) {
 func Test_StaticPool_Invalid(t *testing.T) {
 	p, err := NewPool(
 		context.Background(),
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/invalid.php") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/invalid.php") },
 		pipe.NewPipeFactory(log()),
 		testCfg,
 		log(),
@@ -251,7 +251,7 @@ func Test_StaticPool_Invalid(t *testing.T) {
 func Test_ConfigNoErrorInitDefaults(t *testing.T) {
 	p, err := NewPool(
 		context.Background(),
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			AllocateTimeout: time.Second,
@@ -269,7 +269,7 @@ func Test_StaticPool_Echo(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		testCfg,
 		log(),
@@ -296,7 +296,7 @@ func Test_StaticPool_Echo_NilContext(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		testCfg,
 		log(),
@@ -323,7 +323,7 @@ func Test_StaticPool_Echo_Context(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "head", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "head", "pipes") },
 		pipe.NewPipeFactory(log()),
 		testCfg,
 		log(),
@@ -350,7 +350,7 @@ func Test_StaticPool_JobError(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "error", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "error", "pipes") },
 		pipe.NewPipeFactory(log()),
 		testCfg,
 		log(),
@@ -380,7 +380,7 @@ func Test_StaticPool_Broken_Replace(t *testing.T) {
 
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "broken", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "broken", "pipes") },
 		pipe.NewPipeFactory(log()),
 		testCfg,
 		z,
@@ -407,7 +407,7 @@ func Test_StaticPool_Broken_FromOutside(t *testing.T) {
 
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		cfg2,
 		nil,
@@ -448,7 +448,7 @@ func Test_StaticPool_Broken_FromOutside(t *testing.T) {
 func Test_StaticPool_AllocateTimeout(t *testing.T) {
 	p, err := NewPool(
 		context.Background(),
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "delay", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "delay", "pipes") },
 		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      1,
@@ -468,7 +468,7 @@ func Test_StaticPool_Replace_Worker(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "pid", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "pid", "pipes") },
 		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      1,
@@ -513,7 +513,7 @@ func Test_StaticPool_Debug_Worker(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "pid", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "pid", "pipes") },
 		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			Debug:           true,
@@ -562,7 +562,7 @@ func Test_Static_Pool_Destroy_And_Close(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "delay", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "delay", "pipes") },
 		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      1,
@@ -585,7 +585,7 @@ func Test_Static_Pool_Destroy_And_Close_While_Wait(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "delay", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "delay", "pipes") },
 		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      1,
@@ -616,7 +616,7 @@ func Test_Static_Pool_Handle_Dead(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		context.Background(),
-		func(cmd string) *exec.Cmd {
+		func(cmd []string) *exec.Cmd {
 			return exec.Command("php", "../../tests/slow-destroy.php", "echo", "pipes")
 		},
 		pipe.NewPipeFactory(log()),
@@ -644,7 +644,7 @@ func Test_Static_Pool_Handle_Dead(t *testing.T) {
 func Test_Static_Pool_Slow_Destroy(t *testing.T) {
 	p, err := NewPool(
 		context.Background(),
-		func(cmd string) *exec.Cmd {
+		func(cmd []string) *exec.Cmd {
 			return exec.Command("php", "../../tests/slow-destroy.php", "echo", "pipes")
 		},
 		pipe.NewPipeFactory(log()),
@@ -668,7 +668,7 @@ func Test_StaticPool_ResetTimeout(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		// sleep for the 3 seconds
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/sleep.php", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/sleep.php", "pipes") },
 		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			Debug:           false,
@@ -702,7 +702,7 @@ func Test_StaticPool_NoFreeWorkers(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		// sleep for the 3 seconds
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/sleep.php", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/sleep.php", "pipes") },
 		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			Debug:           false,
@@ -736,7 +736,7 @@ func Test_StaticPool_QueueSize(t *testing.T) {
 	p, err := NewPool(
 		ctx,
 		// sleep for the 3 seconds
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/sleep_short.php", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/sleep_short.php", "pipes") },
 		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			Debug:           false,
@@ -768,7 +768,7 @@ func Test_StaticPool_QueueSize(t *testing.T) {
 func Test_Static_Pool_WrongCommand1(t *testing.T) {
 	p, err := NewPool(
 		context.Background(),
-		func(cmd string) *exec.Cmd {
+		func(cmd []string) *exec.Cmd {
 			return exec.Command("phg", "../../tests/slow-destroy.php", "echo", "pipes")
 		},
 		pipe.NewPipeFactory(log()),
@@ -788,7 +788,7 @@ func Test_Static_Pool_WrongCommand1(t *testing.T) {
 func Test_Static_Pool_WrongCommand2(t *testing.T) {
 	p, err := NewPool(
 		context.Background(),
-		func(cmd string) *exec.Cmd { return exec.Command("php", "", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      5,
@@ -806,7 +806,7 @@ func Test_CRC_WithPayload(t *testing.T) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/crc_error.php") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/crc_error.php") },
 		pipe.NewPipeFactory(log()),
 		testCfg,
 		log(),
@@ -841,7 +841,7 @@ func Benchmark_Pool_Echo(b *testing.B) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		testCfg,
 		log(),
@@ -874,7 +874,7 @@ func Benchmark_Pool_Echo_Batched(b *testing.B) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      uint64(runtime.NumCPU()),
@@ -918,7 +918,7 @@ func Benchmark_Pool_Echo_Replaced(b *testing.B) {
 	ctx := context.Background()
 	p, err := NewPool(
 		ctx,
-		func(cmd string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
+		func(cmd []string) *exec.Cmd { return exec.Command("php", "../../tests/client.php", "echo", "pipes") },
 		pipe.NewPipeFactory(log()),
 		&pool.Config{
 			NumWorkers:      1,


### PR DESCRIPTION
# Reason for This PR

ref: https://github.com/roadrunner-server/roadrunner/issues/1667

## Description of Changes

- Handle `[]string` command case, when user can send raw command and avoid parsing by RR.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
