### PR TITLE
fix: do not add/remove workers in debug mode

### DIFF
--- a/pool/static_pool/workers_pool.go
+++ b/pool/static_pool/workers_pool.go
@@ -119,6 +119,10 @@ func (sp *Pool) Workers() (workers []*worker.Process) {
 }
 
 func (sp *Pool) RemoveWorker(ctx context.Context) error {
+	if sp.cfg.Debug {
+		sp.log.Warn("remove worker operation is not allowed in debug mode")
+		return nil
+	}
 	var cancel context.CancelFunc
 	_, ok := ctx.Deadline()
 	if !ok {
@@ -130,6 +134,10 @@ func (sp *Pool) RemoveWorker(ctx context.Context) error {
 }
 
 func (sp *Pool) AddWorker() error {
+	if sp.cfg.Debug {
+		sp.log.Warn("add worker operation is not allowed in debug mode")
+		return nil
+	}
 	return sp.ww.AddWorker()
 }
 

--- a/worker_watcher/worker_watcher.go
+++ b/worker_watcher/worker_watcher.go
@@ -75,11 +75,6 @@ func (ww *WorkerWatcher) AddWorker() error {
 }
 
 func (ww *WorkerWatcher) RemoveWorker(ctx context.Context) error {
-	// we can't remove worker if there are no workers :)
-	if ww.container.Len() == 0 {
-		return nil
-	}
-
 	w, err := ww.Take(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
# Reason for This PR

- Workers should not be added in debug mode.

## Description of Changes

- Restrict Add/Remove operations in debug mode.
- Correct Remove operation, remove `if len > 0` check.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.
