### PR TITLE
fix: debug mode streaming

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -439,6 +439,7 @@ func (w *Process) Stop() error {
 	// If we successfully sent a stop request, Wait() method will send a struct{} to the doneCh and we're done here
 	// otherwise we have 10 seconds before we kill the process
 	case <-w.doneCh:
+		w.log.Debug("worker stopped", zap.Int("pid", w.pid))
 		return nil
 	case <-time.After(time.Second * 10):
 		// kill process


### PR DESCRIPTION
# Reason for This PR

- Incorrect debug mode streaming information.

## Description of Changes

- Missed the first frame of the stream.
- Incorrect stop operation.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [x] The description of changes is clear and encompassing.
- [x] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [x] All added/changed functionality is tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Chore**: Enhanced Debugging Information
- Added more detailed logging for debugging in `pool/static_pool/debug.go` and `worker/worker.go`. These changes provide better visibility into the worker lifecycle, specifically when a worker is stopped or destroyed.
- Integrated with "github.com/roadrunner-server/sdk/v4/fsm" to manage worker states effectively. This will help in tracking and controlling the worker's state transitions during debug mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->